### PR TITLE
Fix typo: CommenSence → CommonSense

### DIFF
--- a/VLABench/configs/evaluation/dim2task.json
+++ b/VLABench/configs/evaluation/dim2task.json
@@ -20,7 +20,7 @@
         "insert_bloom_flower",
         "select_drink_spatial"
     ],
-    "CommenSence":[
+    "CommonSense":[
         "select_drink_common_sense",
         "select_chemistry_tube_common_sense",
         "add_condiment_common_sense",


### PR DESCRIPTION
Corrected a spelling typo in `dim2task.json` where 'CommenSence' was changed to 'CommonSense' for consistency and accuracy.
